### PR TITLE
feat: add curiosity-driven exploration to PPO

### DIFF
--- a/aitraineree/agents/ppo.py
+++ b/aitraineree/agents/ppo.py
@@ -14,6 +14,7 @@ from aitraineree.buffers.buffer_factory import BufferFactory
 from aitraineree.buffers.rollout import RolloutBuffer
 from aitraineree.loggers import DataLogger
 from aitraineree.networks.bodies import ActorBody
+from aitraineree.networks.curiosity import IntrinsicCuriosityModule
 from aitraineree.policies import MultivariateGaussianPolicy, MultivariateGaussianPolicySimple
 from aitraineree.types import ActionType, AgentState, BufferState, NetworkState
 from aitraineree.types.dataspace import DataSpace
@@ -59,6 +60,12 @@ class PPOAgent(AgentBase):
             entropy_weight (float): Weight of the entropy term in the loss. Default: 0.005.
             max_grad_norm_actor (float) Maximum norm value for actor gradient. Default: 100.
             max_grad_norm_critic (float): Maximum norm value for critic gradient. Default: 100.
+            using_curiosity (bool): Whether to use Intrinsic Curiosity Module. Default: False.
+            curiosity_feature_dim (int): Feature embedding dimension for ICM. Default: 64.
+            curiosity_hidden_layers (tuple of ints): Hidden layers for ICM sub-networks. Default: (128,).
+            curiosity_beta (float): Weight for forward vs inverse loss in ICM. Default: 0.2.
+            curiosity_eta (float): Scaling factor for intrinsic reward. Default: 0.01.
+            curiosity_lr (float): Learning rate for the ICM. Default: 0.001.
 
         """
         super().__init__(**kwargs)
@@ -125,15 +132,41 @@ class PPOAgent(AgentBase):
         self._loss_critic = float("nan")
         self._metrics: dict[str, float] = {}
 
+        self.using_curiosity = bool(self._register_param(kwargs, "using_curiosity", False))
+        if self.using_curiosity:
+            curiosity_feature_dim = int(self._register_param(kwargs, "curiosity_feature_dim", 64))
+            curiosity_hidden_layers = tuple(
+                self._register_param(kwargs, "curiosity_hidden_layers", (128,))
+            )
+            curiosity_beta = float(self._register_param(kwargs, "curiosity_beta", 0.2))
+            curiosity_eta = float(self._register_param(kwargs, "curiosity_eta", 0.01))
+            curiosity_lr = float(self._register_param(kwargs, "curiosity_lr", 1e-3))
+            self.icm = IntrinsicCuriosityModule(
+                obs_shape=self.obs_space.shape,
+                action_size=self.action_size,
+                feature_dim=curiosity_feature_dim,
+                hidden_layers=curiosity_hidden_layers,
+                beta=curiosity_beta,
+                eta=curiosity_eta,
+                device=self.device,
+            )
+            self.icm_opt = optim.Adam(self.icm.parameters(), lr=curiosity_lr)
+            self._loss_icm = float("nan")
+
     @property
     def loss(self) -> dict[str, float]:
-        return {"actor": self._loss_actor, "critic": self._loss_critic}
+        losses = {"actor": self._loss_actor, "critic": self._loss_critic}
+        if self.using_curiosity:
+            losses["icm"] = self._loss_icm
+        return losses
 
     @loss.setter
     def loss(self, value):
         if isinstance(value, dict):
             self._loss_actor = value["actor"]
             self._loss_critic = value["critic"]
+            if "icm" in value:
+                self._loss_icm = value["icm"]
         else:
             self._loss_actor = value
             self._loss_critic = value
@@ -202,7 +235,7 @@ class PPOAgent(AgentBase):
 
         self.iteration += 1
 
-        self.buffer.add(
+        buffer_kwargs = dict(
             obs=torch.tensor(experience.obs).reshape((self.num_workers,) + self.obs_space.shape).float(),
             action=torch.tensor(experience.action).reshape((self.num_workers,) + self.action_space.shape).float(),
             reward=torch.tensor(experience.reward).reshape(self.num_workers, 1),
@@ -210,6 +243,11 @@ class PPOAgent(AgentBase):
             logprob=experience.get("logprob").reshape(self.num_workers, 1),
             value=experience.get("value").reshape(self.num_workers, 1),
         )
+        if self.using_curiosity and experience.next_obs is not None:
+            buffer_kwargs["next_obs"] = (
+                torch.tensor(experience.next_obs).reshape((self.num_workers,) + self.obs_space.shape).float()
+            )
+        self.buffer.add(**buffer_kwargs)
 
         if self.iteration % self.rollout_length == 0:
             self.train_agent()
@@ -226,6 +264,25 @@ class PPOAgent(AgentBase):
         actions = to_tensor(experiences["action"]).to(self.device)
         values = to_tensor(experiences["value"]).to(self.device)
         logprobs = to_tensor(experiences["logprob"]).to(self.device)
+
+        if self.using_curiosity and "next_obs" in experiences:
+            next_obss = to_tensor(experiences["next_obs"]).to(self.device)
+            flat_obs = obss.view(-1, *self.obs_space.shape)
+            flat_next_obs = next_obss.view(-1, *self.obs_space.shape)
+            flat_actions = actions.view(-1, self.action_size)
+            intrinsic_rewards = self.icm.intrinsic_reward(flat_obs, flat_next_obs, flat_actions)
+            intrinsic_rewards = intrinsic_rewards.view(rewards.shape)
+            rewards = rewards + intrinsic_rewards
+            self._metrics["curiosity/intrinsic_reward_mean"] = float(intrinsic_rewards.mean())
+
+            self.icm_opt.zero_grad()
+            icm_loss, forward_loss, inverse_loss = self.icm.compute_loss(flat_obs, flat_next_obs, flat_actions)
+            icm_loss.backward()
+            self.icm_opt.step()
+            self._loss_icm = float(icm_loss.item())
+            self._metrics["curiosity/forward_loss"] = forward_loss
+            self._metrics["curiosity/inverse_loss"] = inverse_loss
+
         assert rewards.shape == dones.shape == values.shape == logprobs.shape
         assert (
             obss.shape == (self.rollout_length, self.num_workers) + self.obs_space.shape
@@ -343,6 +400,8 @@ class PPOAgent(AgentBase):
     def log_metrics(self, data_logger: DataLogger, step: int, full_log: bool = False):
         data_logger.log_value("loss/actor", self._loss_actor, step)
         data_logger.log_value("loss/critic", self._loss_critic, step)
+        if self.using_curiosity:
+            data_logger.log_value("loss/icm", self._loss_icm, step)
         for metric_name, metric_value in self._metrics.items():
             data_logger.log_value(metric_name, metric_value, step)
 
@@ -373,13 +432,14 @@ class PPOAgent(AgentBase):
         )
 
     def get_network_state(self) -> NetworkState:
-        return NetworkState(
-            net=dict(
-                policy=self.policy.state_dict(),
-                actor=self.actor.state_dict(),
-                critic=self.critic.state_dict(),
-            )
+        net = dict(
+            policy=self.policy.state_dict(),
+            actor=self.actor.state_dict(),
+            critic=self.critic.state_dict(),
         )
+        if self.using_curiosity:
+            net["icm"] = self.icm.state_dict()
+        return NetworkState(net=net)
 
     def set_buffer(self, buffer_state: BufferState) -> None:
         self.buffer = BufferFactory.from_state(buffer_state)
@@ -388,6 +448,8 @@ class PPOAgent(AgentBase):
         self.policy.load_state_dict(network_state.net["policy"])
         self.actor.load_state_dict(network_state.net["actor"])
         self.critic.load_state_dict(network_state.net["critic"])
+        if self.using_curiosity and "icm" in network_state.net:
+            self.icm.load_state_dict(network_state.net["icm"])
 
     @staticmethod
     def from_state(state: AgentState) -> AgentBase:

--- a/aitraineree/networks/curiosity.py
+++ b/aitraineree/networks/curiosity.py
@@ -7,20 +7,21 @@ from aitraineree.networks.bodies import FcNet
 
 
 class IntrinsicCuriosityModule(NetworkType):
-
-    """
-    Intrinsic Curiosity Module (ICM) from Pathak et al. (2017).
+    """Intrinsic Curiosity Module (ICM) from Pathak et al. (2017).
 
     Consists of three components:
-    - Feature encoder: maps observations to a learned feature space
-    - Forward model: predicts next-state features given (features, action)
-    - Inverse model: predicts action given (features, next_features)
+
+    - Feature encoder: maps observations to a learned feature space.
+    - Forward model: predicts next-state features given (features, action).
+    - Inverse model: predicts action given (features, next_features).
 
     The intrinsic reward is the L2 prediction error of the forward model.
 
-    Reference:
-        "Curiosity-driven Exploration by Self-supervised Prediction"
-        Pathak et al. (ICML 2017), https://arxiv.org/abs/1705.05363
+    References
+    ----------
+    Pathak et al. "Curiosity-driven Exploration by Self-supervised Prediction"
+    (ICML 2017), https://arxiv.org/abs/1705.05363
+
     """
 
     def __init__(
@@ -33,17 +34,25 @@ class IntrinsicCuriosityModule(NetworkType):
         eta: float = 0.01,
         device=None,
     ):
-        """
-        Initialise the ICM.
+        """Initialise the ICM.
 
-        Parameters:
-            obs_shape: Shape of the observation space.
-            action_size: Dimension of the action space.
-            feature_dim: Dimension of the learned feature embedding.
-            hidden_layers: Hidden layer sizes for sub-networks.
-            beta: Weight for forward vs inverse loss (forward_loss * beta + inverse_loss * (1-beta)).
-            eta: Scaling factor for intrinsic reward.
-            device: Device for tensors.
+        Parameters
+        ----------
+        obs_shape : tuple of int
+            Shape of the observation space.
+        action_size : int
+            Dimension of the action space.
+        feature_dim : int
+            Dimension of the learned feature embedding.
+        hidden_layers : tuple of int
+            Hidden layer sizes for sub-networks.
+        beta : float
+            Weight for forward vs inverse loss.
+        eta : float
+            Scaling factor for intrinsic reward.
+        device : optional
+            Device for tensors.
+
         """
         super().__init__()
 
@@ -81,6 +90,7 @@ class IntrinsicCuriosityModule(NetworkType):
         )
 
     def forward(self, obs, next_obs, actions):
+        """Run the full ICM forward pass."""
         phi = self.feature_encoder(obs)
         phi_next = self.feature_encoder(next_obs)
 
@@ -90,6 +100,7 @@ class IntrinsicCuriosityModule(NetworkType):
         return phi_next, predicted_phi_next, predicted_actions
 
     def intrinsic_reward(self, obs, next_obs, actions):
+        """Compute intrinsic reward as the forward-model prediction error."""
         with torch.no_grad():
             phi_next = self.feature_encoder(next_obs)
             phi = self.feature_encoder(obs)
@@ -99,6 +110,7 @@ class IntrinsicCuriosityModule(NetworkType):
         return reward
 
     def compute_loss(self, obs, next_obs, actions):
+        """Compute the combined forward and inverse model loss."""
         phi_next, predicted_phi_next, predicted_actions = self.forward(obs, next_obs, actions)
 
         forward_loss = 0.5 * F.mse_loss(predicted_phi_next, phi_next.detach())

--- a/aitraineree/networks/curiosity.py
+++ b/aitraineree/networks/curiosity.py
@@ -1,0 +1,103 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from aitraineree.networks import NetworkType
+from aitraineree.networks.bodies import FcNet
+
+
+class IntrinsicCuriosityModule(NetworkType):
+    """Intrinsic Curiosity Module (ICM) from Pathak et al. (2017).
+
+    Consists of three components:
+    - Feature encoder: maps observations to a learned feature space
+    - Forward model: predicts next-state features given (features, action)
+    - Inverse model: predicts action given (features, next_features)
+
+    The intrinsic reward is the L2 prediction error of the forward model.
+
+    Reference:
+        "Curiosity-driven Exploration by Self-supervised Prediction"
+        Pathak et al. (ICML 2017), https://arxiv.org/abs/1705.05363
+    """
+
+    def __init__(
+        self,
+        obs_shape: tuple[int, ...],
+        action_size: int,
+        feature_dim: int = 64,
+        hidden_layers: tuple[int, ...] = (128,),
+        beta: float = 0.2,
+        eta: float = 0.01,
+        device=None,
+    ):
+        """
+        Parameters:
+            obs_shape: Shape of the observation space.
+            action_size: Dimension of the action space.
+            feature_dim: Dimension of the learned feature embedding.
+            hidden_layers: Hidden layer sizes for sub-networks.
+            beta: Weight for forward vs inverse loss (forward_loss * beta + inverse_loss * (1-beta)).
+            eta: Scaling factor for intrinsic reward.
+            device: Device for tensors.
+        """
+        super().__init__()
+
+        self.obs_shape = obs_shape
+        self.action_size = action_size
+        self.feature_dim = feature_dim
+        self.beta = beta
+        self.eta = eta
+
+        self.feature_encoder = FcNet(
+            (obs_shape[0],),
+            (feature_dim,),
+            hidden_layers=hidden_layers,
+            gate=nn.ReLU(),
+            gate_out=nn.ReLU(),
+            device=device,
+        )
+
+        self.forward_model = FcNet(
+            (feature_dim + action_size,),
+            (feature_dim,),
+            hidden_layers=hidden_layers,
+            gate=nn.ReLU(),
+            gate_out=nn.Identity(),
+            device=device,
+        )
+
+        self.inverse_model = FcNet(
+            (feature_dim * 2,),
+            (action_size,),
+            hidden_layers=hidden_layers,
+            gate=nn.ReLU(),
+            gate_out=nn.Identity(),
+            device=device,
+        )
+
+    def forward(self, obs, next_obs, actions):
+        phi = self.feature_encoder(obs)
+        phi_next = self.feature_encoder(next_obs)
+
+        predicted_phi_next = self.forward_model(torch.cat([phi, actions], dim=-1))
+        predicted_actions = self.inverse_model(torch.cat([phi, phi_next], dim=-1))
+
+        return phi_next, predicted_phi_next, predicted_actions
+
+    def intrinsic_reward(self, obs, next_obs, actions):
+        with torch.no_grad():
+            phi_next = self.feature_encoder(next_obs)
+            phi = self.feature_encoder(obs)
+            predicted_phi_next = self.forward_model(torch.cat([phi, actions], dim=-1))
+            reward = self.eta * 0.5 * F.mse_loss(predicted_phi_next, phi_next, reduction="none").sum(dim=-1, keepdim=True)
+        return reward
+
+    def compute_loss(self, obs, next_obs, actions):
+        phi_next, predicted_phi_next, predicted_actions = self.forward(obs, next_obs, actions)
+
+        forward_loss = 0.5 * F.mse_loss(predicted_phi_next, phi_next.detach())
+        inverse_loss = F.mse_loss(predicted_actions, actions)
+
+        loss = self.beta * forward_loss + (1 - self.beta) * inverse_loss
+        return loss, forward_loss.item(), inverse_loss.item()

--- a/aitraineree/networks/curiosity.py
+++ b/aitraineree/networks/curiosity.py
@@ -7,7 +7,9 @@ from aitraineree.networks.bodies import FcNet
 
 
 class IntrinsicCuriosityModule(NetworkType):
-    """Intrinsic Curiosity Module (ICM) from Pathak et al. (2017).
+
+    """
+    Intrinsic Curiosity Module (ICM) from Pathak et al. (2017).
 
     Consists of three components:
     - Feature encoder: maps observations to a learned feature space
@@ -32,6 +34,8 @@ class IntrinsicCuriosityModule(NetworkType):
         device=None,
     ):
         """
+        Initialise the ICM.
+
         Parameters:
             obs_shape: Shape of the observation space.
             action_size: Dimension of the action space.

--- a/aitraineree/networks/curiosity.py
+++ b/aitraineree/networks/curiosity.py
@@ -90,7 +90,8 @@ class IntrinsicCuriosityModule(NetworkType):
             phi_next = self.feature_encoder(next_obs)
             phi = self.feature_encoder(obs)
             predicted_phi_next = self.forward_model(torch.cat([phi, actions], dim=-1))
-            reward = self.eta * 0.5 * F.mse_loss(predicted_phi_next, phi_next, reduction="none").sum(dim=-1, keepdim=True)
+            forward_err = F.mse_loss(predicted_phi_next, phi_next, reduction="none")
+            reward = self.eta * 0.5 * forward_err.sum(dim=-1, keepdim=True)
         return reward
 
     def compute_loss(self, obs, next_obs, actions):

--- a/tests/agents/test_ppo.py
+++ b/tests/agents/test_ppo.py
@@ -8,6 +8,8 @@ from aitraineree.types.dataspace import DataSpace
 from aitraineree.types.state import AgentState, BufferState, NetworkState
 from tests.utils import deterministic_interactions
 
+from tests.utils import feed_agent
+
 t_obs_space = DataSpace(dtype="float", shape=(4,))
 t_action_space = DataSpace(dtype="int", shape=(2,))
 
@@ -161,3 +163,53 @@ def test_ppo_from_state_one_updated():
     assert any([torch.any(x != y) for (x, y) in zip(agent.actor.parameters(), new_agent.actor.parameters())])
     assert any([torch.any(x != y) for (x, y) in zip(agent.critic.parameters(), new_agent.critic.parameters())])
     assert new_agent.buffer != agent.buffer
+
+
+def test_ppo_curiosity_init():
+    agent = PPOAgent(t_obs_space, t_action_space, device="cpu", using_curiosity=True)
+    assert agent.using_curiosity
+    assert hasattr(agent, "icm")
+    assert hasattr(agent, "icm_opt")
+
+
+def test_ppo_curiosity_loss_property():
+    agent = PPOAgent(t_obs_space, t_action_space, device="cpu", using_curiosity=True)
+    loss = agent.loss
+    assert "actor" in loss
+    assert "critic" in loss
+    assert "icm" in loss
+
+
+def test_ppo_curiosity_training():
+    agent = PPOAgent(
+        t_obs_space,
+        t_action_space,
+        device="cpu",
+        using_curiosity=True,
+        rollout_length=10,
+        batch_size=10,
+    )
+    deterministic_interactions(agent, num_iters=10)
+    assert not (agent._loss_actor != agent._loss_actor)  # not NaN
+    assert not (agent._loss_critic != agent._loss_critic)
+
+
+def test_ppo_curiosity_network_state():
+    agent = PPOAgent(t_obs_space, t_action_space, device="cpu", using_curiosity=True)
+    state = agent.get_network_state()
+    assert "icm" in state.net
+
+
+def test_ppo_curiosity_get_state():
+    agent = PPOAgent(t_obs_space, t_action_space, device="cpu", using_curiosity=True)
+    agent_state = agent.get_state()
+    assert isinstance(agent_state, AgentState)
+    assert "icm" in agent_state.network.net
+
+
+def test_ppo_no_curiosity_by_default():
+    agent = PPOAgent(t_obs_space, t_action_space, device="cpu")
+    assert not agent.using_curiosity
+    assert not hasattr(agent, "icm")
+    state = agent.get_network_state()
+    assert "icm" not in state.net

--- a/tests/agents/test_ppo.py
+++ b/tests/agents/test_ppo.py
@@ -8,8 +8,6 @@ from aitraineree.types.dataspace import DataSpace
 from aitraineree.types.state import AgentState, BufferState, NetworkState
 from tests.utils import deterministic_interactions
 
-from tests.utils import feed_agent
-
 t_obs_space = DataSpace(dtype="float", shape=(4,))
 t_action_space = DataSpace(dtype="int", shape=(2,))
 

--- a/tests/networks/test_curiosity.py
+++ b/tests/networks/test_curiosity.py
@@ -1,0 +1,80 @@
+import torch
+
+from aitraineree.networks.curiosity import IntrinsicCuriosityModule
+
+
+def test_icm_forward():
+    obs_shape = (4,)
+    action_size = 2
+    batch_size = 8
+
+    icm = IntrinsicCuriosityModule(obs_shape, action_size, device="cpu")
+    obs = torch.randn(batch_size, *obs_shape)
+    next_obs = torch.randn(batch_size, *obs_shape)
+    actions = torch.randn(batch_size, action_size)
+
+    phi_next, pred_phi_next, pred_actions = icm(obs, next_obs, actions)
+
+    assert phi_next.shape == (batch_size, icm.feature_dim)
+    assert pred_phi_next.shape == (batch_size, icm.feature_dim)
+    assert pred_actions.shape == (batch_size, action_size)
+
+
+def test_icm_intrinsic_reward():
+    obs_shape = (4,)
+    action_size = 2
+    batch_size = 8
+
+    icm = IntrinsicCuriosityModule(obs_shape, action_size, device="cpu")
+    obs = torch.randn(batch_size, *obs_shape)
+    next_obs = torch.randn(batch_size, *obs_shape)
+    actions = torch.randn(batch_size, action_size)
+
+    reward = icm.intrinsic_reward(obs, next_obs, actions)
+    assert reward.shape == (batch_size, 1)
+    assert (reward >= 0).all()
+
+
+def test_icm_compute_loss():
+    obs_shape = (4,)
+    action_size = 2
+    batch_size = 8
+
+    icm = IntrinsicCuriosityModule(obs_shape, action_size, device="cpu")
+    obs = torch.randn(batch_size, *obs_shape)
+    next_obs = torch.randn(batch_size, *obs_shape)
+    actions = torch.randn(batch_size, action_size)
+
+    loss, forward_loss, inverse_loss = icm.compute_loss(obs, next_obs, actions)
+    assert loss.shape == ()
+    assert isinstance(forward_loss, float)
+    assert isinstance(inverse_loss, float)
+
+    loss.backward()
+    for param in icm.parameters():
+        assert param.grad is not None
+
+
+def test_icm_loss_decreases():
+    obs_shape = (4,)
+    action_size = 2
+    batch_size = 32
+
+    icm = IntrinsicCuriosityModule(obs_shape, action_size, device="cpu")
+    optimizer = torch.optim.Adam(icm.parameters(), lr=1e-3)
+
+    obs = torch.randn(batch_size, *obs_shape)
+    next_obs = obs + 0.1 * torch.randn(batch_size, *obs_shape)
+    actions = torch.randn(batch_size, action_size)
+
+    initial_loss, _, _ = icm.compute_loss(obs, next_obs, actions)
+    initial_loss_val = initial_loss.item()
+
+    for _ in range(50):
+        optimizer.zero_grad()
+        loss, _, _ = icm.compute_loss(obs, next_obs, actions)
+        loss.backward()
+        optimizer.step()
+
+    final_loss, _, _ = icm.compute_loss(obs, next_obs, actions)
+    assert final_loss.item() < initial_loss_val


### PR DESCRIPTION
## Summary

Implements the Intrinsic Curiosity Module (ICM) from [Pathak et al. (ICML 2017)](https://arxiv.org/abs/1705.05363) as an opt-in exploration mechanism for `PPOAgent`.

- **New module** `aitraineree/networks/curiosity.py` — `IntrinsicCuriosityModule` with feature encoder, forward model, and inverse model
- **PPO integration** — enabled via `using_curiosity=True`; intrinsic reward (forward-model prediction error) is added to extrinsic rewards during training; ICM is trained jointly with the actor/critic
- **Fully backward-compatible** — `using_curiosity=False` by default, no change in existing behavior

### New config parameters

| Parameter | Default | Description |
|---|---|---|
| `using_curiosity` | `False` | Enable ICM |
| `curiosity_feature_dim` | `64` | Feature embedding dimension |
| `curiosity_hidden_layers` | `(128,)` | Hidden layers for ICM sub-networks |
| `curiosity_beta` | `0.2` | Forward vs inverse loss weight |
| `curiosity_eta` | `0.01` | Intrinsic reward scaling factor |
| `curiosity_lr` | `1e-3` | ICM learning rate |

### References

- [Pathak et al. "Curiosity-driven Exploration by Self-supervised Prediction" (ICML 2017)](https://arxiv.org/abs/1705.05363)
- [Burda et al. "Large-Scale Study of Curiosity-Driven Learning" (ICLR 2019)](https://arxiv.org/abs/1808.04355)

Closes #15

## Test plan

- [x] 4 unit tests for `IntrinsicCuriosityModule` (forward shapes, intrinsic reward, loss + gradients, loss convergence)
- [x] 6 unit tests for PPO with curiosity (init, loss property, training, network state, agent state, default-off)
- [x] All existing PPO tests pass unchanged
- [x] End-to-end validation: ran CartPole-v1 with `using_curiosity=True` for 50 episodes — ICM loss decreases, intrinsic rewards are generated, no errors